### PR TITLE
Adding svg font file exclusion

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,16 +84,25 @@ class WebpackSvgSpritely {
         const asset = module.buildInfo.assets;
 
         Object.keys(asset).map((i) => {
-          if (this.noDuplicates.indexOf(i) === -1) {
-            this.symbols.push(
-              cleanSymbolContents(
-                asset[i]._value.toString('utf8'),
-                getAssetName(i),
-                this.options.prefix
-              )
-            );
+          const contents = asset[i]._value.toString('utf8');
+          // no files missing <svg tag
+          // no files that are font svg files
+          if (contents.indexOf('<svg') !== -1
+            && contents.indexOf('<font') === -1
+            && contents.indexOf('<font') === -1
+            && contents.indexOf('<glyph') === -1
+          ) {
+            if (this.noDuplicates.indexOf(i) === -1) {
+              this.symbols.push(
+                cleanSymbolContents(
+                  contents,
+                  getAssetName(i),
+                  this.options.prefix
+                )
+              );
 
-            this.noDuplicates.push(i);
+              this.noDuplicates.push(i);
+            }
           }
         });
       });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "webpack svg sprite",
     "webpack svg sprite plugin"
   ],
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Plugin that bundles project SVG files into a SVG sprite",
   "repository": "drolsen/webpack-svg-spritely",
   "bugs": {


### PR DESCRIPTION
Problem:
Font svg files were being added to sprite file and thus making sprite files very large for some users.

Solution:
Add a contents check of the files being collected and prevent files that are missing svg tag, have a font tag or have a glyph tag.

This does mean that all fonts used in svg files outside of a font file will need to have its font's collapsed down to vector object in order to be sprited.