### PR TITLE
Dev release

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,11 +117,7 @@ class WebpackSvgSpritely {
 
               this.manifest.push({
                 name: getAssetName(i),
-                source: `${cleanSymbolContents(
-                  contents,
-                  getAssetName(i),
-                  this.options.prefix
-                )}`
+                source: `${contents}`
               })
 
               this.noDuplicates.push(i);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "webpack svg sprite",
     "webpack svg sprite plugin"
   ],
-  "version": "1.3.9",
+  "version": "1.4.0",
   "description": "Plugin that bundles project SVG files into a SVG sprite",
   "repository": "drolsen/webpack-svg-spritely",
   "bugs": {


### PR DESCRIPTION
## Issue
With the introduction of the new manifest JSON file generation, a bug has been discovered that the SVG source prop is actuall the source from post-processed svgs not raw source svgs. This wont work for the majority of manifest JSON file use cases that want to have access to SVGs devoid of any client side assets.

## Fix
- Getting svg source for manifest JSON file vs. sprite source #20