### PR TITLE
2.2.22 Dev Release

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,10 +219,6 @@ class WebpackSvgSpritely {
             const source = asset.source.source().toString('utf8');
             const { name } = asset;
 
-            asset.symbol = cleanSymbolContents(name, this.options.prefix, source);
-            asset.entry = entryFiles.find((entryFile) => chunk.name === entryFile || filename.includes(entryFile));
-
-            process.spritely.manifest.push({name, source});
 
             let hasNoDuplicate = true;
             Object.keys(process.spritely.symbols).map((j) => {
@@ -232,6 +228,9 @@ class WebpackSvgSpritely {
             });
 
             if (hasNoDuplicate) {
+              asset.symbol = cleanSymbolContents(name, this.options.prefix, source);
+              asset.entry = entryFiles.find((entryFile) => chunk.name === entryFile || filename.includes(entryFile));
+              process.spritely.manifest.push({name, source});
               process.spritely.symbols.push(asset);
             }
           }

--- a/index.js
+++ b/index.js
@@ -208,6 +208,10 @@ class WebpackSvgSpritely {
 
   apply(compiler) {
     compiler.hooks.thisCompilation.tap({ name: 'WebpackSvgSpritely' }, (compilation) => {
+      /* Ensures no memory leaks */
+      process.spritely.symbols = [];
+      process.spritely.manifest = [];
+
       /* Gather SVG Symbols & Optional Manifest Data */
       compilation.hooks.chunkAsset.tap('WebpackSvgSpritely', (chunk, filename) => {
         const assets = compilation.getAssets();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "webpack svg sprite",
     "webpack svg sprite plugin"
   ],
-  "version": "2.2.21",
+  "version": "2.2.22",
   "description": "Plugin that bundles project SVG files into a SVG sprite",
   "repository": "drolsen/webpack-svg-spritely",
   "bugs": {


### PR DESCRIPTION
- Ensures that processing and collecting of both symbols and manifest entries are not performed and stored across duplicates
- Ensures that arrays used for symbol and manifest collection are cleared out at the start of new compilations to ensure no memory leaks (useful for webpack dev instances)